### PR TITLE
Use arrayOfSize function instead of new Array(n)

### DIFF
--- a/test/test-really-unique-id.js
+++ b/test/test-really-unique-id.js
@@ -16,7 +16,15 @@ describe('uniqueId', function () {
 })
 
 function generateIds (n) {
-  return map(new Array(n), function () {
+  return map(arrayOfSize(n), function () {
     return uniqueId()
   })
+}
+
+function arrayOfSize (n) {
+  var list = [];
+  for (var i = 0; i < n; i++) {
+    list.push(undefined);
+  }
+  return list;
 }


### PR DESCRIPTION
- `new Array(n)` is not iterable using native methods such as `map` and `forEach`
- Although `new Array(n)` is iterable using lodash and ampersand, swapping this out for native or underscore would break which seems bad
