### PR TITLE
Do not use navigator.plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/QubitProducts/really-unique-id",
   "devDependencies": {
     "amp-each": "^1.0.1",
+    "amp-map": "^1.0.1",
     "amp-unique": "^1.0.1",
     "browserify": "^9.0.3",
     "karma": "^0.12.31",
@@ -32,7 +33,6 @@
     "standard": "^3.2.1"
   },
   "dependencies": {
-    "amp-map": "^1.0.1",
     "string-hash": "^1.1.0"
   }
 }

--- a/really-unique-id.js
+++ b/really-unique-id.js
@@ -1,5 +1,4 @@
 var hash = require('string-hash')
-var map = require('amp-map')
 
 module.exports = uniqueId
 
@@ -46,10 +45,7 @@ function hammerTime () {
  */
 function fingerPrintId () {
   var maxVal = Math.pow(2, 32) - 1
-  var plugins = map(navigator.plugins, function (p) {
-    return p.description
-  }).join('')
-  var fingerPrint = navigator.userAgent + document.cookie + plugins
+  var fingerPrint = navigator.userAgent + document.cookie
   return format(hash(fingerPrint), maxVal)
 }
 

--- a/test/test-really-unique-id.js
+++ b/test/test-really-unique-id.js
@@ -22,9 +22,9 @@ function generateIds (n) {
 }
 
 function arrayOfSize (n) {
-  var list = [];
+  var list = []
   for (var i = 0; i < n; i++) {
-    list.push(undefined);
+    list.push(undefined)
   }
-  return list;
+  return list
 }


### PR DESCRIPTION
Removes `amp-map` as a dependency. `navigator.plugins` add little entropy and are often exactly the same for each browser version.
