### PR TITLE
Ensure that the incrementer doesn't grow forever

### DIFF
--- a/really-unique-id.js
+++ b/really-unique-id.js
@@ -36,7 +36,7 @@ function hammerTime () {
    */
   var doomsDay = new Date()
   doomsDay.setFullYear('2239')
-  return format((new Date()).getTime() + incrementor++, doomsDay.getTime())
+  return format((new Date()).getTime() + (incrementor++ % 10000), doomsDay.getTime())
 }
 
 function format (n, maxVal) {


### PR DESCRIPTION
- e.g. if used in node projects the incrementor could get really big which would cause the ids to grow until it is restarted
